### PR TITLE
Update DarkHelp.hpp to fix std::chrono error

### DIFF
--- a/src-lib/DarkHelp.hpp
+++ b/src-lib/DarkHelp.hpp
@@ -4,7 +4,7 @@
  */
 
 #pragma once
-// fix an std:chrono error
+
 #include <chrono>
 #include <map>
 #include <string>

--- a/src-lib/DarkHelp.hpp
+++ b/src-lib/DarkHelp.hpp
@@ -4,7 +4,8 @@
  */
 
 #pragma once
-
+// fix an std:chrono error
+#include <chrono>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Hello, thanks for the DarkHelp!

I was compiling the dark help following the instructions provided in the readme section.
I am using Ubuntu 18.04, cmake version 3.15.2
I met the following error:
``` 
[ 11%] Building CXX object src-lib/CMakeFiles/dh.dir/DarkHelpUtils.cpp.o
[ 11%] Building CXX object src-lib/CMakeFiles/dh.dir/DarkHelpNN.cpp.o
[ 11%] Building CXX object src-lib/CMakeFiles/dh.dir/DarkHelpConfig.cpp.o
In file included from /home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelp.hpp:122:0,
                 from /home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpPredictionResult.cpp:6:
/home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpNN.hpp:263:9: error: ‘chrono’ in namespace ‘std’ does not name a type
    std::chrono::high_resolution_clock::duration duration;
         ^~~~~~
In file included from /home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelp.hpp:123:0,
                 from /home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpPredictionResult.cpp:6:
/home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpUtils.hpp:27:41: error: ‘chrono’ in namespace ‘std’ does not name a type
  std::string duration_string(const std::chrono::high_resolution_clock::duration duration);
                                         ^~~~~~
/home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpUtils.hpp:27:70: error: expected unqualified-id before ‘::’ token
  std::string duration_string(const std::chrono::high_resolution_clock::duration duration);
                                                                      ^~
/home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpUtils.hpp:27:70: error: expected ‘)’ before ‘::’ token
/home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpUtils.hpp:27:70: error: expected initializer before ‘::’ token
In file included from /home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelp.hpp:122:0,
                 from /home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpNN.cpp:6:
/home/almon-18/almon_projects/darknet_redo/src/DarkHelp/src-lib/DarkHelpNN.hpp:263:9: error: ‘chrono’ in namespace ‘std’ does not name a type
    std::chrono::high_resolution_clock::duration duration;
         ^~~~~~
```

I googled online and it seems that it is missing a ``` #include <chrono>```.
I added it into DarkHelp/src-lib/DarkHelp.hpp and fixed this issue.
